### PR TITLE
feat(home): add concise thoughts and code portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ External Every publications are listed in `content/external_posts.yml`. They
 appear alongside local posts in date order and open their Every page in a new
 tab.
 
+Featured public code projects are listed in `content/github_repositories.yml`.
+The site validates the checked-in snapshot, removes forks and archived entries,
+sorts the remainder by stars, and shows the first seven. Refresh descriptions,
+languages, star counts, and eligibility flags manually when the featured
+projects materially change; the home page never calls GitHub at runtime.
+
 ## Verify
 
 ```bash

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,8 @@
 class PagesController < InertiaController
   def home
     render inertia: "home", props: {
-      posts: ThoughtRepository.all
+      posts: ThoughtRepository.recent(limit: 7),
+      repositories: GithubRepository.all
     }
   end
 

--- a/app/frontend/components/repository_list.test.tsx
+++ b/app/frontend/components/repository_list.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { HomeContent } from '../pages/home'
+import type { GithubRepositorySummary } from '../types/page'
+import { RepositoryList } from './repository_list'
+
+const REPOSITORY: GithubRepositorySummary = {
+  name: 'leva',
+  description: 'LLM evaluation for Rails applications.',
+  language: 'Ruby',
+  stars: 142,
+  url: 'https://github.com/kieranklaassen/leva',
+}
+
+describe('repository list', () => {
+  it('renders repository metadata in a safe external link', () => {
+    const markup = renderToStaticMarkup(<RepositoryList repositories={[REPOSITORY]} />)
+
+    expect(markup).toContain('href="https://github.com/kieranklaassen/leva"')
+    expect(markup).toContain('target="_blank"')
+    expect(markup).toContain('rel="noopener noreferrer"')
+    expect(markup).toContain('LLM evaluation for Rails applications.')
+    expect(markup).toContain('Ruby')
+    expect(markup).toContain('142 stars')
+    expect(markup).toContain('focus-visible:outline-2')
+  })
+
+  it('omits absent optional metadata', () => {
+    const markup = renderToStaticMarkup(
+      <RepositoryList repositories={[{ ...REPOSITORY, description: null, language: null }]} />,
+    )
+
+    expect(markup).not.toContain(REPOSITORY.description)
+    expect(markup).not.toContain('Ruby')
+    expect(markup).toContain('142 stars')
+  })
+
+  it('renders a quiet empty state', () => {
+    const markup = renderToStaticMarkup(<RepositoryList repositories={[]} />)
+
+    expect(markup).toContain('More code is on GitHub.')
+  })
+})
+
+describe('home discovery links', () => {
+  it('links to the complete Thoughts and Code collections', () => {
+    const markup = renderToStaticMarkup(<HomeContent posts={[]} repositories={[REPOSITORY]} />)
+
+    expect(markup).toContain('href="/posts"')
+    expect(markup).toContain('href="https://github.com/kieranklaassen?tab=repositories"')
+    expect(markup.match(/>More</g)).toHaveLength(2)
+    expect(markup).toContain('focus-visible:outline-2')
+  })
+})

--- a/app/frontend/components/repository_list.tsx
+++ b/app/frontend/components/repository_list.tsx
@@ -1,0 +1,35 @@
+import type { GithubRepositorySummary } from '../types/page'
+
+export function RepositoryList({ repositories }: { repositories: GithubRepositorySummary[] }) {
+  if (repositories.length === 0) {
+    return <p className="glass-panel p-5 text-sm text-gray-600">More code is on GitHub.</p>
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {repositories.map((repository) => (
+        <a
+          key={repository.name}
+          href={repository.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="glass-panel block min-h-48 p-5 transition-transform duration-200 hover:-translate-y-1 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-black"
+          aria-label={`${repository.name} on GitHub`}
+        >
+          <h3 className="text-lg font-semibold underline decoration-1 underline-offset-4">
+            {repository.name}
+          </h3>
+          {repository.description && (
+            <p className="mt-3 text-sm leading-relaxed text-gray-700">{repository.description}</p>
+          )}
+          <div className="mt-4 flex items-center justify-between gap-4 text-xs font-medium tracking-wide text-gray-500 uppercase">
+            {repository.language ? <span>{repository.language}</span> : <span />}
+            <span aria-label={`${repository.stars} ${repository.stars === 1 ? 'star' : 'stars'}`}>
+              ★ {repository.stars}
+            </span>
+          </div>
+        </a>
+      ))}
+    </div>
+  )
+}

--- a/app/frontend/components/square_background.test.tsx
+++ b/app/frontend/components/square_background.test.tsx
@@ -147,7 +147,7 @@ describe('interactive square background', () => {
 describe('Inertia page layout', () => {
   it('keeps the site shell outside page components so Inertia can persist it', () => {
     const pages: ReactElement[] = [
-      Home({ posts: [] }),
+      Home({ posts: [], repositories: [] }),
       About(),
       PostsIndex({ posts: [] }),
       NotFound({ requestedPath: '/missing' }),

--- a/app/frontend/pages/home.tsx
+++ b/app/frontend/pages/home.tsx
@@ -1,8 +1,44 @@
-import { Head } from '@inertiajs/react'
+import { Head, Link } from '@inertiajs/react'
 import { PostList } from '../components/post_list'
-import type { PostSummary } from '../types/page'
+import { RepositoryList } from '../components/repository_list'
+import type { GithubRepositorySummary, PostSummary } from '../types/page'
 
-export default function Home({ posts }: { posts: PostSummary[] }) {
+const MORE_LINK_CLASS_NAME =
+  'rounded-sm text-sm font-semibold underline decoration-1 underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-black'
+
+interface HomeProps {
+  posts: PostSummary[]
+  repositories: GithubRepositorySummary[]
+}
+
+export function HomeContent({ posts, repositories }: HomeProps) {
+  return (
+    <section className="mx-auto w-full max-w-[1206px] px-6 pb-24 lg:px-0">
+      <div className="mt-8 mb-5 flex items-baseline justify-between gap-6">
+        <h2 className="text-2xl font-bold">Thoughts</h2>
+        <Link href="/posts" className={MORE_LINK_CLASS_NAME}>
+          More
+        </Link>
+      </div>
+      <PostList posts={posts} />
+
+      <div className="mt-14 mb-5 flex items-baseline justify-between gap-6">
+        <h2 className="text-2xl font-bold">Code</h2>
+        <a
+          href="https://github.com/kieranklaassen?tab=repositories"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={MORE_LINK_CLASS_NAME}
+        >
+          More
+        </a>
+      </div>
+      <RepositoryList repositories={repositories} />
+    </section>
+  )
+}
+
+export default function Home({ posts, repositories }: HomeProps) {
   return (
     <>
       <Head title="Kieran Klaassen">
@@ -12,10 +48,7 @@ export default function Home({ posts }: { posts: PostSummary[] }) {
           content="Essays from Kieran Klaassen about work, life, creativity, and technology."
         />
       </Head>
-      <section className="mx-auto w-full max-w-[1206px] px-6 pb-24 lg:px-0">
-        <h2 className="mt-8 mb-5 text-2xl font-bold">Thoughts</h2>
-        <PostList posts={posts} />
-      </section>
+      <HomeContent posts={posts} repositories={repositories} />
     </>
   )
 }

--- a/app/frontend/types/page.ts
+++ b/app/frontend/types/page.ts
@@ -12,6 +12,14 @@ export interface PostSummary {
   external_url?: string
 }
 
+export interface GithubRepositorySummary {
+  name: string
+  description: string | null
+  language: string | null
+  stars: number
+  url: string
+}
+
 export interface Post extends PostSummary {
   ai_assisted: boolean
   html: string

--- a/app/repositories/github_repository.rb
+++ b/app/repositories/github_repository.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "uri"
+require "yaml"
+
+class GithubRepository
+  SOURCE_PATH = Rails.root.join("content/github_repositories.yml")
+  FEATURED_LIMIT = 7
+
+  class InvalidRepositoryError < StandardError; end
+
+  class << self
+    def all
+      return load_all if Rails.env.development?
+
+      @all ||= load_all
+    end
+
+    def reset!
+      @all = nil
+    end
+
+    private
+
+    def load_all(path = SOURCE_PATH)
+      entries = YAML.safe_load_file(path, permitted_classes: [], aliases: false)
+      raise InvalidRepositoryError, "GitHub repositories must be a list" unless entries.is_a?(Array)
+
+      repositories = entries.map.with_index { |metadata, index| load_repository(metadata, index:) }
+      validate_uniqueness!(repositories)
+
+      repositories
+        .reject { |repository| repository.fetch(:fork) || repository.fetch(:archived) }
+        .sort_by { |repository| [ -repository.fetch(:stars), repository.fetch(:name).downcase ] }
+        .first(FEATURED_LIMIT)
+        .map { |repository| repository.except(:fork, :archived).freeze }
+        .freeze
+    rescue Psych::SyntaxError => error
+      raise InvalidRepositoryError, "invalid GitHub repository YAML (#{error.message})"
+    end
+
+    def load_repository(metadata, index:)
+      raise InvalidRepositoryError, "GitHub repository #{index + 1} must be a mapping" unless metadata.is_a?(Hash)
+
+      name = required_string(metadata, "name", index:)
+      {
+        name:,
+        description: optional_string(metadata, "description", index:),
+        language: optional_string(metadata, "language", index:),
+        stars: required_stars(metadata, index:),
+        url: required_github_url(metadata, index:),
+        fork: required_boolean(metadata, "fork", index:),
+        archived: required_boolean(metadata, "archived", index:)
+      }.freeze
+    end
+
+    def required_string(metadata, key, index:)
+      value = metadata[key]
+      return value.strip if value.is_a?(String) && value.strip.present?
+
+      raise InvalidRepositoryError, "GitHub repository #{index + 1} #{key} must be a non-empty string"
+    end
+
+    def optional_string(metadata, key, index:)
+      value = metadata[key]
+      return if value.nil?
+      return value.strip if value.is_a?(String) && value.strip.present?
+
+      raise InvalidRepositoryError, "GitHub repository #{index + 1} #{key} must be a non-empty string or null"
+    end
+
+    def required_stars(metadata, index:)
+      value = metadata["stars"]
+      return value if value.is_a?(Integer) && value >= 0
+
+      raise InvalidRepositoryError, "GitHub repository #{index + 1} stars must be a non-negative integer"
+    end
+
+    def required_boolean(metadata, key, index:)
+      value = metadata[key]
+      return value if value == true || value == false
+
+      raise InvalidRepositoryError, "GitHub repository #{index + 1} #{key} must be true or false"
+    end
+
+    def required_github_url(metadata, index:)
+      value = required_string(metadata, "url", index:)
+      uri = URI.parse(value)
+      return value if uri.scheme == "https" && uri.host == "github.com" &&
+        uri.path.match?(%r{\A/kieranklaassen/[^/]+\z}) &&
+        uri.query.nil? && uri.fragment.nil?
+
+      raise InvalidRepositoryError,
+        "GitHub repository #{index + 1} url must belong to https://github.com/kieranklaassen"
+    rescue URI::InvalidURIError
+      raise InvalidRepositoryError,
+        "GitHub repository #{index + 1} url must belong to https://github.com/kieranklaassen"
+    end
+
+    def validate_uniqueness!(repositories)
+      validate_unique!(repositories, :name)
+      validate_unique!(repositories, :url)
+    end
+
+    def validate_unique!(repositories, key)
+      duplicates = repositories.group_by { |repository| repository.fetch(key) }
+        .select { |_value, matches| matches.many? }
+        .keys
+      return if duplicates.empty?
+
+      raise InvalidRepositoryError, "duplicate repository #{key}s: #{duplicates.join(', ')}"
+    end
+  end
+end

--- a/app/repositories/thought_repository.rb
+++ b/app/repositories/thought_repository.rb
@@ -8,5 +8,9 @@ class ThoughtRepository
         .reverse
         .freeze
     end
+
+    def recent(limit:)
+      all.first(limit).freeze
+    end
   end
 end

--- a/content/github_repositories.yml
+++ b/content/github_repositories.yml
@@ -1,0 +1,72 @@
+# Maintained snapshot of public, non-fork repositories. Refresh manually when
+# the featured projects or their GitHub metadata materially change.
+- name: leva
+  url: https://github.com/kieranklaassen/leva
+  description: LLM Evaluation Framework for Rails apps to be used with production data.
+  language: Ruby
+  stars: 142
+  fork: false
+  archived: false
+- name: riffrec
+  url: https://github.com/kieranklaassen/riffrec
+  description: Capture golden product feedback sessions with screen, voice, DOM, network, and console context for AI agents.
+  language: TypeScript
+  stars: 87
+  fork: false
+  archived: false
+- name: hotkeys-rails
+  url: https://github.com/kieranklaassen/hotkeys-rails
+  description: Keyboard shortcuts for Hotwire apps. No dependencies. No configuration. Just HTML.
+  language: Ruby
+  stars: 36
+  fork: false
+  archived: false
+- name: blazer-ai
+  url: https://github.com/kieranklaassen/blazer-ai
+  description: AI-powered natural language to SQL generation for Blazer using RubyLLM.
+  language: Ruby
+  stars: 30
+  fork: false
+  archived: false
+- name: laters
+  url: https://github.com/kieranklaassen/laters
+  description: Run any instance method of an Active Record model via a job by adding `_later` to it.
+  language: Ruby
+  stars: 9
+  fork: false
+  archived: false
+- name: gpt-auto-pr-description-action
+  url: https://github.com/kieranklaassen/gpt-auto-pr-description-action
+  description: Automatically draft pull request descriptions with OpenAI.
+  language: Ruby
+  stars: 6
+  fork: false
+  archived: false
+- name: codeigniter-mollie-ideal-api
+  url: https://github.com/kieranklaassen/codeigniter-mollie-ideal-api
+  description: CodeIgniter version of the Mollie iDEAL API in PHP.
+  language: PHP
+  stars: 5
+  fork: false
+  archived: false
+- name: breathwork
+  url: https://github.com/kieranklaassen/breathwork
+  description:
+  language: TypeScript
+  stars: 4
+  fork: false
+  archived: false
+- name: codeigniter-mollie-sms-api
+  url: https://github.com/kieranklaassen/codeigniter-mollie-sms-api
+  description: CodeIgniter version of the Mollie SMS API in PHP.
+  language: PHP
+  stars: 3
+  fork: false
+  archived: false
+- name: farmbot-agent-cli-mcp
+  url: https://github.com/kieranklaassen/farmbot-agent-cli-mcp
+  description: Agent-native CLI and MCP server for FarmBot hardware control.
+  language: JavaScript
+  stars: 3
+  fork: false
+  archived: false

--- a/docs/plans/2026-08-05-001-feat-home-thoughts-code-sections-plan.md
+++ b/docs/plans/2026-08-05-001-feat-home-thoughts-code-sections-plan.md
@@ -1,0 +1,194 @@
+---
+title: Home Thoughts and Code Sections - Plan
+type: feat
+date: 2026-08-05
+deepened: 2026-08-05
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Home Thoughts and Code Sections - Plan
+
+## Goal Capsule
+
+- **Objective:** Make the home page a concise portfolio by showing up to seven recent thoughts and up to seven highest-starred public GitHub repositories from a maintained snapshot.
+- **Authority:** The Product Contract defines visible behavior. The Planning Contract defines the implementation mechanism.
+- **Execution profile:** Extend the current repository-backed content, Rails-owned Inertia props, and React card-grid patterns without adding a runtime API dependency.
+- **Stop conditions:** Stop if repository metadata cannot be represented as trusted version-controlled content or if the complete Thoughts index would be truncated with the home preview.
+- **Tail ownership:** The implementation includes automated tests, browser verification, and production bundle verification.
+
+---
+
+## Product Contract
+
+### Summary
+
+The home page will show the seven newest Thoughts, a clear path to the complete Thoughts archive, and a Code section containing seven public repositories ordered by star count. The full Thoughts index remains unchanged.
+
+### Problem Frame
+
+The home page currently renders every local and external article. The growing list makes the page less useful as a quick introduction to Kieran's work, while public code projects are absent even though they are a second important body of work.
+
+### Requirements
+
+**Thoughts discovery**
+
+- R1. The home page shows up to the seven newest entries from the combined local and Every Thoughts collection; when fewer than seven exist, it shows all of them.
+- R2. The home page always provides a visible More control that opens the existing complete Thoughts index.
+- R3. The complete Thoughts index continues to show every Thought in its existing newest-first order.
+
+**Code discovery**
+
+- R4. The home page includes a Code section below Thoughts.
+- R5. The Code section shows up to seven public, non-archived, source repositories owned by `kieranklaassen` and recorded in the maintained snapshot, ordered by descending GitHub star count and then repository name.
+- R6. Each repository card links to GitHub and shows its name, description when present, primary language when present, and star count.
+- R7. The Code section provides a More control that opens Kieran's GitHub repositories page.
+- R8. Repository metadata comes from a version-controlled content file. Before it reaches page props, each entry is validated for required name, HTTPS GitHub URL owned by `kieranklaassen`, non-negative integer star count, boolean eligibility flags, and unique name and URL. Public, non-archived, and source status are author-asserted snapshot facts; malformed content fails fast instead of rendering.
+
+**Rendering and accessibility**
+
+- R9. Repository data is delivered through Rails-owned Inertia props so server rendering and the first hydrated render remain identical.
+- R10. More controls and repository cards are keyboard reachable, have clear labels, and preserve visible focus treatment.
+
+### Acceptance Examples
+
+- AE1. **Covers R1-R3.** Given more than seven Thoughts, when a visitor opens the home page, then seven newest cards appear and More opens `/posts`, where the complete collection appears.
+- AE2. **Covers R4-R7.** Given public repositories with different star counts, when a visitor opens the home page, then the Code section shows at most seven source repositories in descending star order and each card opens its GitHub URL.
+- AE3. **Covers R8-R9.** Given the repository content file has no entries, when a visitor opens the home page, then the page still responds successfully and renders a quiet Code empty state without a hydration mismatch.
+
+### Scope Boundaries
+
+- The work does not add repository detail pages, search, filters, contribution graphs, private repositories, or GitHub authentication for visitors.
+- The work does not change Thought card content, article ordering, post routes, or the complete Thoughts index layout.
+- The work does not add a database, live GitHub request, or recurring synchronization job.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Store a maintained snapshot of the highest-starred public source repositories as version-controlled content.** (session-settled: user-directed — chosen over live GitHub API loading: real-time data is not needed.) A YAML file follows the site's existing Every-publication content pattern and keeps the home page independent of GitHub availability. The file may contain more than seven eligible entries; the loader owns final ordering and selection.
+- KTD2. **Treat star counts as maintained snapshot metadata and sort in the repository layer.** The content file records repository facts, while the loader filters eligibility, orders by descending stars with a repository-name tie-breaker, and returns seven entries. A database was rejected because this small trusted collection needs no runtime writes or persistence service.
+- KTD3. **Keep the complete Thoughts collection at the repository boundary and limit only the home-page projection.** The `/posts` route remains the canonical archive while the home controller receives a seven-item slice.
+- KTD4. **Reuse the existing glass-panel grid language.** Repository cards and More controls should feel native to the current page while remaining visually distinct enough to scan as Code rather than Thoughts.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["Version-controlled repository list"] --> B["Repository loader and validation"]
+  B --> C["Seven star-sorted summaries"]
+  C --> D["Rails home props"]
+  D --> E["Inertia SSR and hydration"]
+```
+
+### Assumptions
+
+- “My public repositories” means repositories owned by `kieranklaassen`; forks and archived repositories are excluded from the featured Code section.
+- Both home-page sections use a seven-item preview and a More control. Thoughts More goes to `/posts`; Code More goes to `https://github.com/kieranklaassen?tab=repositories`.
+- GitHub star counts are a maintained snapshot and may lag behind GitHub. The list should be refreshed when repository prominence changes; exact real-time counts are not required.
+- An empty Code collection renders a small non-blocking empty state instead of hiding the heading or surfacing a technical error to visitors.
+
+### Risks and Dependencies
+
+- Snapshot metadata can drift from GitHub. The content format and README guidance must make manual updates obvious, while tests must depend only on repository fixtures rather than current GitHub values.
+- Repository descriptions are trusted project content, but URLs must still be validated as public `https://github.com/kieranklaassen/...` links to prevent accidental off-domain cards.
+- Duplicate repository names or URLs would create repeated cards. The loader rejects invalid or duplicate records using the same fail-fast posture as the existing external-publication loader.
+
+### System-Wide Impact
+
+- **Request latency:** Repository data loads from local trusted content and introduces no network I/O or new service dependency.
+- **Failure propagation:** Invalid checked-in metadata fails fast at the repository boundary during development and tests instead of reaching React as a malformed card.
+- **Content lifecycle:** Star counts and descriptions change only when the YAML snapshot changes, so deployments are deterministic and reviewable.
+- **Rendering:** Rails passes one normalized payload to both Inertia SSR and hydration. No effect, loading transition, or client refetch changes first-render markup.
+
+### Sources and Research
+
+- `app/controllers/pages_controller.rb` owns home-page props.
+- `app/repositories/thought_repository.rb` owns the combined newest-first Thoughts collection.
+- `app/frontend/pages/home.tsx` and `app/frontend/components/post_list.tsx` establish the section and card-grid patterns.
+- `content/external_posts.yml` and `app/repositories/external_post_repository.rb` establish the trusted version-controlled external-content pattern.
+
+---
+
+## Implementation Units
+
+### U1. GitHub repository content projection
+
+- **Goal:** Produce a validated, deterministic list of public repository summaries from version-controlled content.
+- **Requirements:** R5, R6, R8, R9; KTD1, KTD2.
+- **Dependencies:** None.
+- **Files:** `content/github_repositories.yml`, `app/repositories/github_repository.rb`, `test/repositories/github_repository_test.rb`, `README.md`.
+- **Approach:** Add a YAML list containing the repository name, GitHub URL, description, primary language, star snapshot, and eligibility flags needed by the UI. Add a repository boundary that validates and normalizes the records, excludes archived or forked entries, sorts by stars and name, limits the result to seven, and freezes the collection. Document how to refresh the snapshot manually.
+- **Patterns to follow:** Mirror the class-level, immutable collection interface in `app/repositories/thought_repository.rb` and the validation-focused tests in `test/repositories/external_post_repository_test.rb`.
+- **Test scenarios:**
+  1. Given a well-formed content file, normalization sorts by descending stars, breaks equal-star ties by name, and produces only the card fields.
+  2. Given forks, archived entries, and more than seven eligible records, the projection excludes ineligible entries and returns seven records.
+  3. Given missing descriptions or languages, normalization preserves a valid card payload with nullable optional fields.
+  4. Given a duplicate name or URL, the loader raises a clear content-validation error.
+  5. Given a non-GitHub URL, a negative or non-integer star count, or a missing required field, the loader raises a clear content-validation error.
+  6. Given an empty YAML list, the projection returns an empty immutable collection.
+  7. Given the checked-in `content/github_repositories.yml`, the loader validates and normalizes the real shipped content without raising.
+- **Verification:** Repository tests prove the checked-in content and fixtures satisfy validation, eligibility filtering, ordering, limiting, optional fields, and empty input without network access.
+
+### U2. Home Thoughts preview and Code props
+
+- **Goal:** Give the home page its bounded Thoughts and Code collections while preserving the full archive.
+- **Requirements:** R1, R3, R5, R8, R9; KTD3.
+- **Dependencies:** U1.
+- **Files:** `app/repositories/thought_repository.rb`, `app/controllers/pages_controller.rb`, `test/repositories/thought_repository_test.rb`, `test/integration/public_routes_test.rb`.
+- **Approach:** Add a bounded recent-Thoughts projection or equivalent repository-level operation for the home action. Keep the posts index on the complete collection. Add the normalized Code collection to the home Inertia props and use repository stubs in integration tests to cover populated and empty Code states explicitly.
+- **Patterns to follow:** Continue passing explicit props from Rails controllers and keep `ThoughtRepository.all` as the complete canonical collection.
+- **Test scenarios:**
+  1. **Covers AE1.** The home response contains the first seven entries from `ThoughtRepository.all` in identical order and exposes no later entry.
+  2. **Covers AE1.** The posts index response still contains every Thought.
+  3. **Covers AE2.** The home response includes the normalized Code collection from the repository content boundary.
+  4. **Covers AE3.** An empty Code collection still produces a successful home response.
+- **Verification:** Repository and integration tests prove the home-only limit, unchanged archive behavior, and Rails-owned Code props.
+
+### U3. Code cards and More controls
+
+- **Goal:** Render the concise home-page portfolio with accessible paths to the complete writing and code collections.
+- **Requirements:** R2, R4, R6, R7, R10; KTD4.
+- **Dependencies:** U2.
+- **Files:** `app/frontend/pages/home.tsx`, `app/frontend/components/repository_list.tsx`, `app/frontend/components/repository_list.test.tsx`, `app/frontend/types/page.ts`, `test/integration/inertia_ssr_test.rb`.
+- **Approach:** Add the Thoughts More control beside its heading, then render a Code section below the Thoughts preview. Repository cards open external GitHub pages safely and use semantic labels for language and stars. The empty state remains compact. Keep all initial output prop-driven so SSR and hydration match.
+- **Patterns to follow:** Reuse `PostList` grid sizing, `glass-panel` card treatment, external-link safety attributes, and existing visible-focus utilities.
+- **Test scenarios:**
+  1. **Covers AE1.** Static home markup includes a More link to `/posts` adjacent to the Thoughts heading.
+  2. **Covers AE2.** Repository cards render names, optional descriptions, languages, star counts, and external-link safety attributes.
+  3. A repository without a description or language omits the absent metadata without leaving empty visual labels.
+  4. The Code More control points to Kieran's GitHub repositories page and opens safely as an external link.
+  5. **Covers AE3.** An empty repository collection renders the quiet empty state in both server and browser markup.
+  6. Both More controls and repository cards are reachable in tab order and carry the shared visible-focus utility classes.
+- **Verification:** Frontend tests assert card and link semantics, strict SSR includes both section headings and prop-driven repository content, and browser review confirms responsive grid balance and visible keyboard focus at mobile and desktop widths.
+
+---
+
+## Verification Contract
+
+| Gate | Applies to | Done signal |
+|---|---|---|
+| `bin/rails test` | U1, U2, U3 | Content-repository, route, and non-strict SSR tests pass. |
+| `npm run test:frontend` | U3 | Repository-card, More-control, empty-state, and existing component tests pass. |
+| `npm run check` | U3 | Browser and SSR TypeScript projects compile without type errors. |
+| `npm run build` | U3 | Production browser and SSR bundles build successfully. |
+| Strict Inertia SSR test with the built renderer | U3 | Raw home HTML contains the bounded Thoughts section, Code heading, and repository content with no hydration-only dependency. |
+| `bin/rubocop` | U1, U2 | Ruby changes satisfy repository style. |
+| `bin/brakeman --no-pager` | U1, U2 | No new security warning is introduced. |
+| Browser review through Rails-proxied Vite | U3 | Mobile and desktop layouts show clear section boundaries, More controls are discoverable, keyboard focus is visible, and external cards behave correctly. |
+
+---
+
+## Definition of Done
+
+- The home page shows seven newest Thoughts and links to the unchanged complete Thoughts index.
+- The home page shows a Code section with up to seven eligible repositories in deterministic star order and a link to the complete GitHub repositories page.
+- Repository metadata is version-controlled, validated, and deterministic; the home page performs no GitHub API request.
+- Rails owns all initial page props; raw SSR contains the visible sections and repository content when data is available.
+- Automated Ruby, frontend, type, production-build, style, security, strict SSR, and responsive browser checks pass.
+- No database, background synchronization, or private token is introduced.
+- Dead-end, duplicate, or experimental code from implementation is removed before shipping.

--- a/test/integration/inertia_ssr_test.rb
+++ b/test/integration/inertia_ssr_test.rb
@@ -10,10 +10,11 @@ class InertiaSsrTest < ActionDispatch::IntegrationTest
     assert_includes response.body, 'data-server-rendered="true"'
     assert_includes response.body, "Thoughts"
     assert_includes response.body, "Code"
-    assert_includes response.body, "Unlocking Ideas"
     assert_includes response.body, "How I Polish Software That Agents Built"
     assert_includes response.body, "leva"
     assert_includes response.body, 'target="_blank"'
+    assert_includes response.body, ThoughtRepository.recent(limit: 7).last.fetch(:title)
+    refute_includes response.body, ThoughtRepository.all.fetch(7).fetch(:title)
   end
 
   test "raw article HTML contains its body and metadata" do

--- a/test/integration/inertia_ssr_test.rb
+++ b/test/integration/inertia_ssr_test.rb
@@ -9,8 +9,10 @@ class InertiaSsrTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, 'data-server-rendered="true"'
     assert_includes response.body, "Thoughts"
+    assert_includes response.body, "Code"
     assert_includes response.body, "Unlocking Ideas"
     assert_includes response.body, "How I Polish Software That Agents Built"
+    assert_includes response.body, "leva"
     assert_includes response.body, 'target="_blank"'
   end
 

--- a/test/integration/public_routes_test.rb
+++ b/test/integration/public_routes_test.rb
@@ -1,15 +1,29 @@
 require "test_helper"
 
 class PublicRoutesTest < ActionDispatch::IntegrationTest
-  test "home exposes every post through the Inertia page" do
+  test "home exposes seven recent thoughts and the repository snapshot" do
     get root_path
 
     assert_response :success
     assert_inertia_component "home"
     summaries = inertia.props.fetch("posts")
-    assert_equal ThoughtRepository.all.map { |post| post.fetch(:title) }, summaries.map { |post| post.fetch("title") }
-    assert_equal ThoughtRepository.all.map { |post| post.fetch(:path) }, summaries.map { |post| post.fetch("path") }
-    assert_equal 13, summaries.count { |post| post.key?("external_url") }
+    repositories = inertia.props.fetch("repositories")
+    assert_equal ThoughtRepository.all.first(7).map { |post| post.fetch(:title) },
+      summaries.map { |post| post.fetch("title") }
+    assert_equal ThoughtRepository.all.first(7).map { |post| post.fetch(:path) },
+      summaries.map { |post| post.fetch("path") }
+    assert_equal GithubRepository.all.map { |repository| repository.fetch(:name) },
+      repositories.map { |repository| repository.fetch("name") }
+  end
+
+  test "home succeeds with an empty repository snapshot" do
+    GithubRepository.instance_variable_set(:@all, [].freeze)
+    get root_path
+
+    assert_response :success
+    assert_empty inertia.props.fetch("repositories")
+  ensure
+    GithubRepository.reset!
   end
 
   test "public content remains available to older browsers" do

--- a/test/repositories/github_repository_test.rb
+++ b/test/repositories/github_repository_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+require "tmpdir"
+
+class GithubRepositoryTest < ActiveSupport::TestCase
+  setup do
+    GithubRepository.reset!
+  end
+
+  test "loads the checked-in repository snapshot" do
+    repositories = GithubRepository.all
+
+    assert_equal 7, repositories.size
+    assert_equal "leva", repositories.first.fetch(:name)
+    assert repositories.frozen?
+    assert repositories.all?(&:frozen?)
+  end
+
+  test "sorts eligible repositories by stars and name and limits the result" do
+    entries = 9.times.map do |index|
+      repository_entry(
+        name: "project-#{index}",
+        stars: index == 7 || index == 8 ? 20 : index
+      )
+    end
+    entries << repository_entry(name: "archived", stars: 100, archived: true)
+    entries << repository_entry(name: "forked", stars: 100, fork: true)
+
+    repositories = load_entries(entries)
+
+    assert_equal 7, repositories.size
+    assert_equal %w[project-7 project-8 project-6 project-5 project-4 project-3 project-2],
+      repositories.map { |repository| repository.fetch(:name) }
+    assert repositories.all? { |repository| repository.keys == %i[name description language stars url] }
+  end
+
+  test "allows missing optional card metadata" do
+    repository = load_entries([
+      repository_entry(name: "minimal", description: nil, language: nil)
+    ]).sole
+
+    assert_nil repository.fetch(:description)
+    assert_nil repository.fetch(:language)
+  end
+
+  test "returns an empty immutable collection for an empty snapshot" do
+    repositories = load_entries([])
+
+    assert_empty repositories
+    assert repositories.frozen?
+  end
+
+  test "rejects duplicate names and urls" do
+    duplicate_name = [ repository_entry(name: "same"), repository_entry(name: "same", stars: 2) ]
+    duplicate_url = [
+      repository_entry(name: "first", url: "https://github.com/kieranklaassen/shared"),
+      repository_entry(name: "second", url: "https://github.com/kieranklaassen/shared")
+    ]
+
+    name_error = assert_raises(GithubRepository::InvalidRepositoryError) { load_entries(duplicate_name) }
+    url_error = assert_raises(GithubRepository::InvalidRepositoryError) { load_entries(duplicate_url) }
+
+    assert_match "duplicate repository names: same", name_error.message
+    assert_match "duplicate repository urls: https://github.com/kieranklaassen/shared", url_error.message
+  end
+
+  test "rejects malformed required metadata" do
+    invalid_entries = {
+      "missing name" => repository_entry.except("name"),
+      "foreign url" => repository_entry(url: "https://example.com/project"),
+      "negative stars" => repository_entry(stars: -1),
+      "string stars" => repository_entry(stars: "1"),
+      "missing fork flag" => repository_entry.except("fork")
+    }
+
+    invalid_entries.each do |label, entry|
+      assert_raises(GithubRepository::InvalidRepositoryError, label) { load_entries([ entry ]) }
+    end
+  end
+
+  private
+
+  def load_entries(entries)
+    Dir.mktmpdir do |directory|
+      path = Pathname(directory).join("github_repositories.yml")
+      path.write(entries.to_yaml)
+      return GithubRepository.send(:load_all, path)
+    end
+  end
+
+  def repository_entry(name: "project", url: nil, description: "A project", language: "Ruby", stars: 1,
+    fork: false, archived: false)
+    {
+      "name" => name,
+      "url" => url || "https://github.com/kieranklaassen/#{name}",
+      "description" => description,
+      "language" => language,
+      "stars" => stars,
+      "fork" => fork,
+      "archived" => archived
+    }
+  end
+end

--- a/test/repositories/thought_repository_test.rb
+++ b/test/repositories/thought_repository_test.rb
@@ -9,4 +9,13 @@ class ThoughtRepositoryTest < ActiveSupport::TestCase
     assert thoughts.any? { |post| post.fetch(:slug) == "unlocking-ideas" }
     assert thoughts.any? { |post| post.fetch(:slug) == "every-compound-engineering" }
   end
+
+  test "returns a bounded recent projection without changing the complete collection" do
+    thoughts = ThoughtRepository.all
+    recent = ThoughtRepository.recent(limit: 7)
+
+    assert_equal thoughts.first(7), recent
+    assert_equal PostRepository.all.size + ExternalPostRepository.all.size, thoughts.size
+    assert recent.frozen?
+  end
 end


### PR DESCRIPTION
## Summary

The home page now gives visitors a concise view of Kieran's writing and open-source work. It shows the seven newest Thoughts with a path to the complete archive, then highlights seven public source repositories ranked by a checked-in star snapshot.

Repository metadata stays in version-controlled content. The page makes no runtime GitHub request, so server rendering remains deterministic and availability does not depend on GitHub.

Session-settled decisions carried from planning: use a manually maintained content snapshot instead of live GitHub loading (user-directed).

## Validation

- The full Rails suite passed: 37 runs and 336 assertions, with no failures.
- Frontend tests passed: 13 tests across 2 files.
- Type checks, production browser and SSR builds, Ruby style checks, and the security scan passed.
- Strict server-rendering checks confirmed the seven-item Thought preview and Code content appear in raw HTML.
- Desktop and mobile browser review confirmed responsive card layouts, visible keyboard focus, working More links, safe external links, and no console errors.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only content loading and home UI changes; no auth, payments, or external API at request time.
> 
> **Overview**
> The home page becomes a short portfolio instead of listing every Thought: it shows **seven newest** posts (via `ThoughtRepository.recent`) with a **More** link to `/posts`, while `/posts` still serves the full archive.
> 
> A new **Code** section highlights up to **seven** public repos from a checked-in `content/github_repositories.yml` snapshot. `GithubRepository` validates entries, drops forks/archived repos, sorts by stars, and never calls GitHub at runtime. Rails passes `repositories` through Inertia; `RepositoryList` renders accessible external cards (or a quiet empty state).
> 
> README and integration/SSR tests document and lock in the bounded home preview and Code props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cfe29b623715ba3ee53c15b8b6da9302a83c556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->