### PR TITLE
feat(home): feature pinned code projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ appear alongside local posts in date order and open their Every page in a new
 tab.
 
 Featured public code projects are listed in `content/github_repositories.yml`.
-The site validates the checked-in snapshot, removes forks and archived entries,
-sorts the remainder by stars, and shows the first seven. Refresh descriptions,
-languages, star counts, and eligibility flags manually when the featured
-projects materially change; the home page never calls GitHub at runtime.
+The file mirrors the repositories pinned on Kieran's GitHub profile and its
+order controls the cards on the home page. The site validates the checked-in
+snapshot, removes forks and archived entries, and shows up to seven pins.
+Refresh the list and metadata manually when the profile pins change; the home
+page never calls GitHub at runtime.
 
 ## Verify
 

--- a/app/repositories/github_repository.rb
+++ b/app/repositories/github_repository.rb
@@ -31,7 +31,6 @@ class GithubRepository
 
       repositories
         .reject { |repository| repository.fetch(:fork) || repository.fetch(:archived) }
-        .sort_by { |repository| [ -repository.fetch(:stars), repository.fetch(:name).downcase ] }
         .first(FEATURED_LIMIT)
         .map { |repository| repository.except(:fork, :archived).freeze }
         .freeze
@@ -87,14 +86,14 @@ class GithubRepository
       value = required_string(metadata, "url", index:)
       uri = URI.parse(value)
       return value if uri.scheme == "https" && uri.host == "github.com" &&
-        uri.path.match?(%r{\A/kieranklaassen/[^/]+\z}) &&
+        uri.path.match?(%r{\A/[^/]+/[^/]+\z}) &&
         uri.query.nil? && uri.fragment.nil?
 
       raise InvalidRepositoryError,
-        "GitHub repository #{index + 1} url must belong to https://github.com/kieranklaassen"
+        "GitHub repository #{index + 1} url must be an https://github.com repository URL"
     rescue URI::InvalidURIError
       raise InvalidRepositoryError,
-        "GitHub repository #{index + 1} url must belong to https://github.com/kieranklaassen"
+        "GitHub repository #{index + 1} url must be an https://github.com repository URL"
     end
 
     def validate_uniqueness!(repositories)

--- a/content/github_repositories.yml
+++ b/content/github_repositories.yml
@@ -1,10 +1,10 @@
-# Maintained snapshot of public, non-fork repositories. Refresh manually when
-# the featured projects or their GitHub metadata materially change.
-- name: leva
-  url: https://github.com/kieranklaassen/leva
-  description: LLM Evaluation Framework for Rails apps to be used with production data.
-  language: Ruby
-  stars: 142
+# Maintained snapshot of the repositories pinned on Kieran's GitHub profile.
+# File order is display order. Refresh manually when the pins or their metadata change.
+- name: Compound Engineering
+  url: https://github.com/EveryInc/compound-engineering-plugin
+  description: Official Compound Engineering plugin for Claude Code, Codex, Cursor, and more.
+  language: TypeScript
+  stars: 24017
   fork: false
   archived: false
 - name: riffrec
@@ -14,59 +14,17 @@
   stars: 87
   fork: false
   archived: false
-- name: hotkeys-rails
-  url: https://github.com/kieranklaassen/hotkeys-rails
-  description: Keyboard shortcuts for Hotwire apps. No dependencies. No configuration. Just HTML.
+- name: leva
+  url: https://github.com/kieranklaassen/leva
+  description: LLM Evaluation Framework for Rails apps to be used with production data.
   language: Ruby
-  stars: 36
+  stars: 142
   fork: false
   archived: false
-- name: blazer-ai
-  url: https://github.com/kieranklaassen/blazer-ai
-  description: AI-powered natural language to SQL generation for Blazer using RubyLLM.
+- name: thinkroom
+  url: https://github.com/kieranklaassen/thinkroom
+  description: Thinkroom — where deeper thinking compounds.
   language: Ruby
-  stars: 30
-  fork: false
-  archived: false
-- name: laters
-  url: https://github.com/kieranklaassen/laters
-  description: Run any instance method of an Active Record model via a job by adding `_later` to it.
-  language: Ruby
-  stars: 9
-  fork: false
-  archived: false
-- name: gpt-auto-pr-description-action
-  url: https://github.com/kieranklaassen/gpt-auto-pr-description-action
-  description: Automatically draft pull request descriptions with OpenAI.
-  language: Ruby
-  stars: 6
-  fork: false
-  archived: false
-- name: codeigniter-mollie-ideal-api
-  url: https://github.com/kieranklaassen/codeigniter-mollie-ideal-api
-  description: CodeIgniter version of the Mollie iDEAL API in PHP.
-  language: PHP
-  stars: 5
-  fork: false
-  archived: false
-- name: breathwork
-  url: https://github.com/kieranklaassen/breathwork
-  description:
-  language: TypeScript
-  stars: 4
-  fork: false
-  archived: false
-- name: codeigniter-mollie-sms-api
-  url: https://github.com/kieranklaassen/codeigniter-mollie-sms-api
-  description: CodeIgniter version of the Mollie SMS API in PHP.
-  language: PHP
-  stars: 3
-  fork: false
-  archived: false
-- name: farmbot-agent-cli-mcp
-  url: https://github.com/kieranklaassen/farmbot-agent-cli-mcp
-  description: Agent-native CLI and MCP server for FarmBot hardware control.
-  language: JavaScript
-  stars: 3
+  stars: 22
   fork: false
   archived: false

--- a/test/repositories/github_repository_test.rb
+++ b/test/repositories/github_repository_test.rb
@@ -9,17 +9,18 @@ class GithubRepositoryTest < ActiveSupport::TestCase
   test "loads the checked-in repository snapshot" do
     repositories = GithubRepository.all
 
-    assert_equal 7, repositories.size
-    assert_equal "leva", repositories.first.fetch(:name)
+    assert_equal 4, repositories.size
+    assert_equal [ "Compound Engineering", "riffrec", "leva", "thinkroom" ],
+      repositories.map { |repository| repository.fetch(:name) }
     assert repositories.frozen?
     assert repositories.all?(&:frozen?)
   end
 
-  test "sorts eligible repositories by stars and name and limits the result" do
+  test "preserves pinned order while excluding ineligible repositories and limiting the result" do
     entries = 9.times.map do |index|
       repository_entry(
         name: "project-#{index}",
-        stars: index == 7 || index == 8 ? 20 : index
+        stars: 9 - index
       )
     end
     entries << repository_entry(name: "archived", stars: 100, archived: true)
@@ -28,9 +29,20 @@ class GithubRepositoryTest < ActiveSupport::TestCase
     repositories = load_entries(entries)
 
     assert_equal 7, repositories.size
-    assert_equal %w[project-7 project-8 project-6 project-5 project-4 project-3 project-2],
+    assert_equal %w[project-0 project-1 project-2 project-3 project-4 project-5 project-6],
       repositories.map { |repository| repository.fetch(:name) }
     assert repositories.all? { |repository| repository.keys == %i[name description language stars url] }
+  end
+
+  test "allows a pinned repository from another GitHub organization" do
+    repository = load_entries([
+      repository_entry(
+        name: "Compound Engineering",
+        url: "https://github.com/EveryInc/compound-engineering-plugin"
+      )
+    ]).sole
+
+    assert_equal "https://github.com/EveryInc/compound-engineering-plugin", repository.fetch(:url)
   end
 
   test "allows missing optional card metadata" do


### PR DESCRIPTION
## Summary

The home page Code section now mirrors Kieran's current GitHub pins instead of filling seven slots from a star-ranked repository list. Compound Engineering appears first, followed by riffrec, leva, and thinkroom in profile order.

The pins remain a checked-in snapshot, so the production page still makes no GitHub request. The loader now preserves content order and accepts pinned repositories from other GitHub organizations while continuing to reject off-domain URLs, forks, and archived entries.

## Validation

- `bin/rails test` — 38 runs, 337 assertions, no failures
- `bin/rubocop` — 36 files, no offenses

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-order and static content changes only; validation still restricts URLs to github.com and excludes forks/archived repos.
> 
> **Overview**
> The home **Code** cards now follow **GitHub profile pin order** from `content/github_repositories.yml` instead of picking seven repos by star count. The checked-in snapshot is trimmed to four pins (including **EveryInc/compound-engineering-plugin** first), and the README documents that file order is display order.
> 
> `GithubRepository` **drops star-based sorting** after filtering forks/archived entries, still caps at seven, and **widens URL validation** to any `https://github.com/{owner}/{repo}` path (not only `kieranklaassen`). Tests assert pinned order, cross-org URLs, and the new snapshot contents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baca2a0d1df8d2547ad5c4460d49335038ba2ca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->